### PR TITLE
Add strongSelf check in API client

### DIFF
--- a/Sources/VGSCheckoutSDK/Core/Collect/CollectCore/API/APIClient.swift
+++ b/Sources/VGSCheckoutSDK/Core/Collect/CollectCore/API/APIClient.swift
@@ -199,21 +199,22 @@ extension APIClient {
 
 	private func updateHost(with hostname: String, completion: ((URL) -> Void)? = nil) {
 
-		dataSyncQueue.async { [self] in
+		dataSyncQueue.async {[weak self] in
+			guard let strongSelf = self else {return}
 
 			// Enter sync zone.
-			self.syncSemaphore.wait()
+			strongSelf.syncSemaphore.wait()
 
 			// Check if we already have URL. If yes, don't fetch it the same time.
-			if let url = self.hostURLPolicy.url {
+			if let url = strongSelf.hostURLPolicy.url {
 				completion?(url)
 				// Quite sync zone.
-				self.syncSemaphore.signal()
+				strongSelf.syncSemaphore.signal()
 				return
 			}
 
 			// Resolve hostname.
-			APIHostnameValidator.validateCustomHostname(hostname, tenantId: self.vaultId, formAnalyticDetails: self.formAnalyticDetails) {[weak self](url) in
+			APIHostnameValidator.validateCustomHostname(hostname, tenantId: strongSelf.vaultId, formAnalyticDetails: strongSelf.formAnalyticDetails) {[weak self](url) in
 				if var validUrl = url {
 
 					// Update url scheme if needed.


### PR DESCRIPTION
- fix strongSelf check in `APIClient` to prevent retain cycle.